### PR TITLE
Update Swift Version to 4.0

### DIFF
--- a/ObjectMapper+Realm.podspec
+++ b/ObjectMapper+Realm.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.dependency "RealmSwift"
 
   s.pod_target_xcconfig = {
-    'SWIFT_VERSION' => '3.0',
+    'SWIFT_VERSION' => '4.0',
   }
   s.source_files = "ObjectMapper+Realm/*.swift"
 end


### PR DESCRIPTION
Cannot build ObjectMapper+Relam in Xcode 10.2.1 through cocoapods.