### PR TITLE
iOS 9 is now the minimum supported version

### DIFF
--- a/ObjectMapper+Realm.podspec
+++ b/ObjectMapper+Realm.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author           = { 'Jake Peterson' => 'hello@jakenberg.io' }
   s.source           = { :git => 'https://github.com/jakenberg/ObjectMapper-Realm.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.9"
   s.tvos.deployment_target = "10.0"
 

--- a/ObjectMapper+Realm.podspec
+++ b/ObjectMapper+Realm.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ObjectMapper+Realm'
-  s.version          = '0.9'
+  s.version          = '1.1'
   s.summary          = "A Realm extension that serializes arbitrary JSON into Realm's List class"
 
   s.homepage         = 'https://github.com/jakenberg/ObjectMapper-Realm'


### PR DESCRIPTION
### Context

In [Realm 5.2.0](https://github.com/realm/realm-cocoa/releases/tag/v5.2.0) they updated their minimum supported deployment targets, and due that and if you update your realm dependency to the latest you will start to see this issue:
![Screen Shot 2020-07-28 at 11 37 37 AM](https://user-images.githubusercontent.com/176254/88707710-82d09b00-d0c7-11ea-9ef0-caf9951d34e2.png)

### What's in here?

This PR update minimum supported version to iOS 9. This in order to be in line with the updates made in [Realm 5.2.0](https://github.com/realm/realm-cocoa/releases/tag/v5.2.0)

This PR will solve https://github.com/Jakenberg/ObjectMapper-Realm/issues/40

### Testing Steps

Until this PR is merged you can temporally use the following:
```
pod 'ObjectMapper+Realm', :git => 'git@github.com:Guerrix/ObjectMapper-Realm.git', :branch => 'feature/UpdateMinimumSupportedVersions'
```
After run `pod install` the error should go away and all should be good to go.

